### PR TITLE
white-space: nowrap

### DIFF
--- a/offscreen.scss
+++ b/offscreen.scss
@@ -8,6 +8,7 @@
 	overflow: hidden;
 	width: 1px;
 	height: 1px;
+	white-space: nowrap;
 
 	[dir="rtl"] & {
 		left: auto;

--- a/offscreen.scss
+++ b/offscreen.scss
@@ -1,20 +1,17 @@
 
 @mixin vui-offscreen() {
-	position: absolute !important;
-	overflow: hidden;
 
+	$offset: -10000px;
+
+	position: absolute !important;
+	left: $offset;
+	overflow: hidden;
 	width: 1px;
 	height: 1px;
 
-	font-size: 1px;
-	line-height: 1px;
-	text-indent: 2px;
-	white-space: nowrap;
+	[dir="rtl"] & {
+		left: auto;
+		right: $offset;
+	}
 
-	padding: 0;
-	margin: 0;
-	background: none;
-	border: none;
-	box-shadow: none;
-	outline: none !important; // important to override :focus
 }


### PR DESCRIPTION
Don't use a linewrap - Fixes issues in NVDA and VoiceOver

- NVDA would, in some situations, read text without spaces when contained in a 1px-wide element
- VoiceOver would read word-by-word when in a 1px-wide element
- By making it not wrap, but still overflow, both are able to read text without any issues

Reverting on-screen indented changes, but keeping the `white-space: nowrap;` that it introduced. Detailed better in the individual commits.